### PR TITLE
Error on installation (deprecated call)

### DIFF
--- a/src/Bundle/InnomaticLegacyBundle/Composer/ScriptHandler.php
+++ b/src/Bundle/InnomaticLegacyBundle/Composer/ScriptHandler.php
@@ -14,7 +14,7 @@
 namespace Innomatic\Bundle\InnomaticLegacyBundle\Composer;
 
 use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler as DistributionBundleScriptHandler;
-use Composer\Script\CommandEvent;
+use Composer\Script\Event;
 
 class ScriptHandler extends DistributionBundleScriptHandler
 {
@@ -23,9 +23,9 @@ class ScriptHandler extends DistributionBundleScriptHandler
      *
      * For better interoperability, assets are copied instead of symlinked by default.
      *
-     * @param $event CommandEvent A instance
+     * @param $event Event A instance
      */
-    public static function installAssets(CommandEvent $event)
+    public static function installAssets(Event $event)
     {
         $options = self::getOptions($event);
         $appDir = $options['symfony-app-dir'];


### PR DESCRIPTION
The Composer\Script\CommandEvent is deprecated and cause an error on installation.

Replaced the CommandEvent for Composer\Script\Event to make the installation work
